### PR TITLE
[457324] Error on launching Android emulator

### DIFF
--- a/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/adt/AndroidSDKManager.java
+++ b/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/adt/AndroidSDKManager.java
@@ -441,7 +441,7 @@ public class AndroidSDKManager {
 	
 	private String getAndroidCommand(){
 		String command = "android";
-		return isWindows() ? "cmd /c " + command : command; 
+		return isWindows() ? "cmd /c " + command :  "./" + command; 
 	}
 	
 	private String getADBCommand(){


### PR DESCRIPTION
Fix a problem with executing android command on Mac and Linux.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=457324
Change-Id: I40632b5dce7891c642247025cd0c58dec239a36c
Signed-off-by: wgalanciak wojciech.galanciak@gmail.com
